### PR TITLE
Support hex KIT card chip numbers

### DIFF
--- a/workspace/chip_number.go
+++ b/workspace/chip_number.go
@@ -1,0 +1,38 @@
+package workspace
+
+import (
+	"strconv"
+	"strings"
+)
+
+func parseChipNumber(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+
+	chipNumber, err := strconv.ParseUint(s, 10, 64)
+	if err == nil {
+		return chipNumber, nil
+	}
+
+	hexStr := s
+	if strings.HasPrefix(strings.ToLower(hexStr), "0x") {
+		hexStr = hexStr[2:]
+	}
+
+	chipNumber, err = strconv.ParseUint(hexStr, 16, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	// Some newer KIT cards are stored as 7-byte hex IDs. The RFID reader reports
+	// the first four bytes in little-endian order, so normalize to that value.
+	if len(hexStr) == 14 {
+		b := make([]byte, 7)
+		for i := 0; i < 7; i++ {
+			val, _ := strconv.ParseUint(hexStr[i*2:i*2+2], 16, 8)
+			b[i] = byte(val)
+		}
+		chipNumber = uint64(b[3])<<24 | uint64(b[2])<<16 | uint64(b[1])<<8 | uint64(b[0])
+	}
+
+	return chipNumber, nil
+}

--- a/workspace/workspace_admin.go
+++ b/workspace/workspace_admin.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	admin "google.golang.org/api/admin/directory/v1"
 	"log"
-	"strconv"
 )
 
 type customArguments struct {
@@ -93,7 +92,7 @@ func GetAuthorisedFuksUsers() (authUsers []AuthorisedUser, _ error) {
 				continue
 			}
 
-			chipNumber, err := strconv.ParseUint(customArgs.ChipNumber, 10, 64)
+			chipNumber, err := parseChipNumber(customArgs.ChipNumber)
 			if err != nil {
 				log.Printf("Couldn't parse '%s' to uint64: user.PrimaryEmail=%s",
 					customArgs.ChipNumber, user.PrimaryEmail)

--- a/workspace/workspace_sheets.go
+++ b/workspace/workspace_sheets.go
@@ -2,7 +2,6 @@ package workspace
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -43,7 +42,7 @@ func GetAuthChipNumbersFromSheet() (users []AuthorisedUser, _ error) {
 			continue
 		}
 
-		chipNumber, err := strconv.ParseUint(chipNumStr, 10, 64)
+		chipNumber, err := parseChipNumber(chipNumStr)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Summary
- add shared chip-number parsing for decimal and hex KIT card values
- support 7-byte KIT card hex IDs by normalizing to the RFID reader value
- use the parser for both Google Workspace users and Google Sheet chip numbers

## Validation
- gofmt ran on changed Go files
- go test ./... could not complete in this local checkout because embedded credentials/certificates are absent and go.sum entries are incomplete